### PR TITLE
[Feat] User Table에 isActive와 generation(기수) 추가

### DIFF
--- a/prisma/migrations/20221208153604_modify_user_table/migration.sql
+++ b/prisma/migrations/20221208153604_modify_user_table/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Added the required column `generation` to the `user` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "user" ADD COLUMN     "generation" INTEGER NOT NULL,
+ADD COLUMN     "is_active" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,8 @@ model User {
   name        String
   phone       String
   position    UserPosition
+  isActive    Boolean      @defualt(true) @map("is_active")
+  generation  Int
   userAccount UserAccount?
   createdAt   DateTime     @default(now()) @map("created_at")
   updatedAt   DateTime     @updatedAt @map("updated_at")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,7 @@ model User {
   name        String
   phone       String
   position    UserPosition
-  isActive    Boolean      @defualt(true) @map("is_active")
+  isActive    Boolean      @default(true) @map("is_active")
   generation  Int
   userAccount UserAccount?
   createdAt   DateTime     @default(now()) @map("created_at")


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Improvement
- [x] New feature
- [ ] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc


## Purpose
- 어떤 목적의 작업 인가요?
1. User Table에 기수를 추가하여서 특정 회원이 몇 기수였는지 확인
2. isActive를 통해 활동하지 않는 회원들을 분류 가능

## Why
- 어떤 이유로 작업 하셨나요?


## Related issue
- 관련된 Ticket을 첨부해 주세요.
resolve #13

## Additional context
- 추가로 알리고 싶으신 내용이 있으신가요?
테이블 수정을 머지 혹은 컨펌받은 다음에, 엑셀 등록부터 빠르게 수정하겠습니다.

## Checklist
- Merge 나 Deploy 시 확인이 필요한 부분이 있다면 적어주세요.
