### PR TITLE
[FEAT] 미가입 유저들의 승인코드를 .xlsx로 내려주기

### DIFF
--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -40,7 +40,7 @@ export class UserController {
     return this.userService.enrollByXlsx(file);
   }
 
-  @ApiOperation({ summary: '아직 가입되지 않은 유저들의 승인코드를 생성해서 내려줌' })
+  @ApiOperation({ summary: '유저들의 승인코드가 담긴 xlsx파일을 base64형태로 생성해서 내려줌' })
   @ApiOkResponse()
   @HttpCode(200)
   @Get('/access-code')

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,6 +1,6 @@
-import { Body, Controller, HttpCode, Post, UploadedFile, UseInterceptors } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, Post, UploadedFile, UseInterceptors } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { ApiBody, ApiConsumes, ApiCreatedResponse, ApiNoContentResponse, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiConsumes, ApiCreatedResponse, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { UserService } from './user.service';
 import { TestDto } from './dto/test.dto';
 import { TestPayload } from './payload/test.payload';
@@ -19,15 +19,13 @@ export class UserController {
     return this.userService.test(payload);
   }
 
-  @ApiOperation({
-    summary: '합격자 정보가 담긴 엑셀 파일 업로드를 통해 서버에 정보 등록',
-  })
+  @ApiOperation({ summary: '합격자 정보가 담긴 엑셀 파일 업로드를 통해 서버에 정보 등록' })
   @ApiConsumes('multipart/form-data')
   @ApiBody({
     schema: {
       type: 'object',
       properties: {
-        file: { 
+        file: {
           type: 'string',
           format: 'binary',
         },
@@ -35,10 +33,18 @@ export class UserController {
     },
   })
   @ApiCreatedResponse()
-  @Post('/xlsx')
   @HttpCode(201)
+  @Post('/xlsx')
   @UseInterceptors(FileInterceptor('file', xlsxEnrollOption))
   async enrollByXlsx(@UploadedFile() file: Express.Multer.File): Promise<void> {
     return this.userService.enrollByXlsx(file);
+  }
+
+  @ApiOperation({ summary: '아직 가입되지 않은 유저들의 승인코드를 생성해서 내려줌' })
+  @ApiOkResponse()
+  @HttpCode(200)
+  @Get('/access-code')
+  async getAccessCode() {
+    return this.userService.getAccessCode();
   }
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -44,7 +44,7 @@ export class UserController {
   @ApiOkResponse()
   @HttpCode(200)
   @Get('/access-code')
-  async getAccessCode() {
-    return this.userService.getAccessCode();
+  async generateXlsxWithAccessCode(): Promise<string> {
+    return this.userService.generateXlsxWithAccessCode();
   }
 }

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -14,7 +14,7 @@ export class UserRepository {
   async getNotJoinedUserList(): Promise<User[]> {
     return this.prisma.user.findMany({
       where: {
-        userAccount: undefined,
+        userAccount: null,
       },
     });
   }

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { User } from '@prisma/client';
 import { PrismaService } from '../common/services/prisma.service';
 import { XlsxEnrollDao } from './dao/xlsx-enroll.dao';
 
@@ -8,5 +9,13 @@ export class UserRepository {
 
   async enroll(data: XlsxEnrollDao[]): Promise<void> {
     await this.prisma.user.createMany({ data: data, skipDuplicates: true });
+  }
+
+  async getNotJoinedUserList(): Promise<User[]> {
+    return this.prisma.user.findMany({
+      where: {
+        userAccount: undefined,
+      },
+    });
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -73,8 +73,9 @@ export class UserService {
         .createHash('sha512')
         .update(studentId + this.config.get<string>('ACCESS_CODE_SALT'))
         .digest('hex');
+      const convertedPhone = '0' + phone.substring(3);
 
-      return { 이름: name, 학번: studentId, 전화번호: phone, 포지션: position, 승인코드: accessCode };
+      return { 이름: name, 학번: studentId, 전화번호: convertedPhone, 포지션: position, 승인코드: accessCode };
     });
 
     // 엑셀 파일 작성

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { UserRepository } from './user.repository';
 import { TestPayload } from './payload/test.payload';
 import { TestDto } from './dto/test.dto';
@@ -7,10 +8,12 @@ import * as XLSX from 'xlsx';
 import { XlsxEnrollDao } from './dao/xlsx-enroll.dao';
 import { UserPosition } from './types/user-position.enum';
 import { validate } from 'class-validator';
+import * as crypto from 'crypto';
+import { access } from 'fs';
 
 @Injectable()
 export class UserService {
-  constructor(private readonly userRepository: UserRepository) {}
+  constructor(private readonly userRepository: UserRepository, private readonly config: ConfigService) {}
 
   async test(payload: TestPayload): Promise<TestDto> {
     // 필요한 경우 주입받은 userRepository를 사용하여 DB에 접근합니다.
@@ -33,7 +36,6 @@ export class UserService {
       defval: null, //defaultValue: null
     });
 
-    
     // XLSX -> JSON DAO 형식으로 맞추기
     const generation = sheet['G3'].v;
     const xlsxEnrollData: XlsxEnrollDao[] = xlsxRows.map((row) => {
@@ -59,5 +61,32 @@ export class UserService {
 
     // DB 등록하기
     return this.userRepository.enroll(xlsxEnrollData);
+  }
+
+  async getAccessCode() {
+    // DB에서 미가입된 유저들의 목록을 받아옴
+    const userList = await this.userRepository.getNotJoinedUserList();
+
+    // 승인코드 생성
+    const userAccessCodeList = userList.map((user) => {
+      const { name, studentId, phone, position } = user;
+      const accessCode = crypto
+        .createHash('sha512')
+        .update(studentId + this.config.get<string>('ACCESS_CODE_SALT'))
+        .digest('hex');
+
+      return { name, studentId, phone, position, accessCode };
+    });
+    console.log(userAccessCodeList);
+
+    // 엑셀 파일 작성
+    const workBook = XLSX.utils.book_new();
+    const workSheet = XLSX.utils.json_to_sheet(userAccessCodeList);
+    XLSX.utils.book_append_sheet(workBook, workSheet, '승인코드');
+    const xlsxFile = XLSX.write(workBook, {
+      bookType: 'xlsx',
+      type: 'base64',
+    });
+    return xlsxFile;
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -62,19 +62,16 @@ export class UserService {
     return this.userRepository.enroll(xlsxEnrollData);
   }
 
-  async getAccessCode() {
+  async generateXlsxWithAccessCode(): Promise<string> {
     // DB에서 미가입된 유저들의 목록을 받아옴
     const userList = await this.userRepository.getNotJoinedUserList();
+    console.log(userList);
 
     // 승인코드 생성
     const userAccessCodeList = userList.map((user) => {
       const { name, studentId, phone, position } = user;
-      const accessCode = crypto
-        .createHash('sha512')
-        .update(studentId + this.config.get<string>('ACCESS_CODE_SALT'))
-        .digest('hex');
+      const accessCode = this.generateAccessCode(studentId);
       const convertedPhone = '0' + phone.substring(3);
-
       return { 이름: name, 학번: studentId, 전화번호: convertedPhone, 포지션: position, 승인코드: accessCode };
     });
 
@@ -89,5 +86,12 @@ export class UserService {
     });
 
     return xlsxFile;
+  }
+
+  generateAccessCode(studentId: number): string {
+    return crypto
+      .createHash('sha512')
+      .update(studentId + this.config.get<string>('ACCESS_CODE_SALT'))
+      .digest('hex');
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -9,7 +9,6 @@ import { XlsxEnrollDao } from './dao/xlsx-enroll.dao';
 import { UserPosition } from './types/user-position.enum';
 import { validate } from 'class-validator';
 import * as crypto from 'crypto';
-import { access } from 'fs';
 
 @Injectable()
 export class UserService {
@@ -75,18 +74,19 @@ export class UserService {
         .update(studentId + this.config.get<string>('ACCESS_CODE_SALT'))
         .digest('hex');
 
-      return { name, studentId, phone, position, accessCode };
+      return { 이름: name, 학번: studentId, 전화번호: phone, 포지션: position, 승인코드: accessCode };
     });
-    console.log(userAccessCodeList);
 
     // 엑셀 파일 작성
     const workBook = XLSX.utils.book_new();
     const workSheet = XLSX.utils.json_to_sheet(userAccessCodeList);
     XLSX.utils.book_append_sheet(workBook, workSheet, '승인코드');
+    workSheet['!cols'] = [{ wpx: 75 }, { wpx: 100 }, { wpx: 125 }, { wpx: 75 }, { wpx: 500 }];
     const xlsxFile = XLSX.write(workBook, {
       bookType: 'xlsx',
       type: 'base64',
     });
+
     return xlsxFile;
   }
 }


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Improvement
- [x] New feature
- [ ] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc


## Purpose
- 어떤 목적의 작업 인가요?
미가입 유저들의 회원가입 승인코드 생성 및 엑셀파일로 내려줌

## Why
- 어떤 이유로 작업 하셨나요?
issue, slack 참고

## Related issue
- 관련된 Ticket을 첨부해 주세요.
resolve #3 

## Additional context
- 추가로 알리고 싶으신 내용이 있으신가요?
1. 내려주는 파일이 base64형태로 이루어져있어서, 프론트에서 이를 따로 fileSaver와 같은 라이브러리로 base64에서 .xlsx로 바꾸는 작업이 필요합니다.
  - https://github.com/SheetJS/sheetjs/issues/122 를 참고하였습니다.

2. 파일이 잘 생성되는지는 이미 다 테스트 했습니다.
  - https://products.aspose.app/pdf/ko/conversion/excel-to-base64 여기에서 테스트 할 수 있습니다.

3. 승인코드를 생성하는 코드가 단 한줄 밖에 없어서, 따로 메소드로 분리하지 않았습니다.
  - 따로 분리할지는 코멘트 남겨주세요.

## Checklist
- Merge 나 Deploy 시 확인이 필요한 부분이 있다면 적어주세요.
